### PR TITLE
added check for legal xml attribute names

### DIFF
--- a/starlab.py
+++ b/starlab.py
@@ -278,6 +278,7 @@ def kiraout_to_xml(theuuid):
 
     storystart = re.compile("^\((\w+)")
     storyend = re.compile("^\)(\w+)")
+    illegalstart = re.compile("^-")
 
     for line in store:
         if storystart.match(line):
@@ -300,7 +301,11 @@ def kiraout_to_xml(theuuid):
         else:
             chunks = re.split("=", line)
             if len(chunks) == 2:
-                xmlfile.write("<value %s=\"%s\" />\n" %(re.sub("\,* ","_",chunks[0].strip()), chunks[1].strip()))
+                # xml attributes can't begin with punctuation or a digit. Make sure we abide by that rule.
+                if re.match("^\s*[a-zA-Z]", chunks[0]):
+                    xmlfile.write("<value %s=\"%s\" />\n" %(re.sub("\,* ","_",chunks[0].strip()), chunks[1].strip()))
+                else:
+                    xmlfile.write(line)
             else:
                 xmlfile.write(line)
 


### PR DESCRIPTION
As of right now, it doesn't try to fix the name or make it legal, it just includes illegal variable names as a line of log text instead of as an attribute.  I can do something more sophisticated later if we decide we need it.

Once you accept this pull request (and then pull it down to atlacamani) you'll need to rerun starlab.kiraout_to_xml() for each of the affected runs.
